### PR TITLE
Fix join game memory issue

### DIFF
--- a/src/app/api/game/create/route.ts
+++ b/src/app/api/game/create/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-
-// Game storage in memory (in production, you'd use a database)
-const games = new Map<string, any>()
+import { games } from '@/lib/game-store'
 
 export async function POST(request: NextRequest) {
   try {
@@ -62,12 +60,4 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// Helper function to get game (exported for use in other routes)
-export function getGame(gameId: string) {
-  return games.get(gameId)
-}
-
-// Helper function to update game (exported for use in other routes)
-export function updateGame(gameId: string, gameData: any) {
-  games.set(gameId, { ...gameData, updatedAt: new Date().toISOString() })
-}
+// Game utility functions are provided by '@/lib/game-store'

--- a/src/app/api/game/join/route.ts
+++ b/src/app/api/game/join/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getGame, updateGame } from '../create/route'
+import { getGame, updateGame } from '@/lib/game-store'
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/game/move/route.ts
+++ b/src/app/api/game/move/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getGame, updateGame } from '../create/route'
+import { getGame, updateGame } from '@/lib/game-store'
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/lib/game-store.ts
+++ b/src/lib/game-store.ts
@@ -1,0 +1,36 @@
+export interface Player {
+  id: string
+  name: string
+  color: string
+}
+
+export interface Game {
+  id: string
+  board: string[][]
+  currentPlayer: string
+  players: Player[]
+  winner: string | null
+  isDraw: boolean
+  boardSize: number
+  createdAt: string
+  updatedAt: string
+}
+
+declare global {
+  var games: Map<string, Game> | undefined
+}
+
+const globalForGames = globalThis as unknown as { games: Map<string, Game> | undefined }
+
+export const games: Map<string, Game> = globalForGames.games ?? new Map()
+if (!globalForGames.games) {
+  globalForGames.games = games
+}
+
+export function getGame(gameId: string): Game | undefined {
+  return games.get(gameId)
+}
+
+export function updateGame(gameId: string, gameData: Game) {
+  games.set(gameId, { ...gameData, updatedAt: new Date().toISOString() })
+}

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,5 +1,5 @@
 import { Server } from 'socket.io';
-import { getGame, updateGame } from '@/app/api/game/create/route';
+import { getGame, updateGame } from '@/lib/game-store';
 
 export const setupSocket = (io: Server) => {
   io.on('connection', (socket) => {


### PR DESCRIPTION
## Summary
- create global game store shared by API routes and socket
- use global store for create, join, and move API
- update socket to use new store

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68884280ec3083249aa9496e41367a3c