### PR TITLE
Fix player join visibility

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -9,11 +9,13 @@ export const setupSocket = (io: Server) => {
     socket.on('join-game', (gameId: string) => {
       socket.join(`game-${gameId}`);
       console.log(`Client ${socket.id} joined game ${gameId}`);
-      
+
       // Send current game state to the client
       const game = getGame(gameId);
       if (game) {
         socket.emit('game-state', game);
+        // notify other players in the room that a player joined
+        socket.to(`game-${gameId}`).emit('game-updated', game);
       }
     });
 


### PR DESCRIPTION
## Summary
- broadcast an updated game state when a player joins so others see the join event

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688851cc6a0c8324a437953dd974ecf4