### PR TITLE
Block used colors when joining game

### DIFF
--- a/src/app/api/game/details/route.ts
+++ b/src/app/api/game/details/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getGame } from '@/lib/game-store'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const gameId = searchParams.get('gameId')
+    if (!gameId) {
+      return NextResponse.json(
+        { success: false, error: 'Missing gameId' },
+        { status: 400 }
+      )
+    }
+
+    const game = getGame(gameId)
+    if (!game) {
+      return NextResponse.json(
+        { success: false, error: 'Game not found' },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({ success: true, game })
+  } catch (error) {
+    console.error('[GET /api/game/details] error', error)
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/game/join/route.ts
+++ b/src/app/api/game/join/route.ts
@@ -33,6 +33,15 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Ensure chosen color is not already taken
+    const colorTaken = game.players.some((p: any) => p.color === playerColor)
+    if (colorTaken) {
+      return NextResponse.json(
+        { success: false, error: 'Color already taken' },
+        { status: 400 }
+      )
+    }
+
     // Check if player already exists in game
     const existingPlayer = game.players.find((p: any) => p.name === playerName)
     if (existingPlayer) {


### PR DESCRIPTION
## Summary
- add endpoint to fetch game details
- validate chosen color when joining a game
- fetch taken colors on join page and disable used colors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893d006ae883248ce6b051e2060ab6