### PR TITLE
Add scoreboard tracking wins

### DIFF
--- a/src/app/api/game/move/route.ts
+++ b/src/app/api/game/move/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getGame, updateGame } from '@/lib/game-store'
 import { BLOCKED_CELL } from '@/lib/constants'
+import { addWin } from '@/lib/scoreboard-store'
 
 export async function POST(request: NextRequest) {
   try {
@@ -74,6 +75,11 @@ export async function POST(request: NextRequest) {
     }
 
     updateGame(gameId, updatedGame)
+
+    if (winner) {
+      const winnerName = game.players.find((p: any) => p.id === winner)?.name ?? 'Unknown'
+      addWin(winnerName)
+    }
 
     console.log('[POST /api/game/move] move processed', { gameId, row, col, winner, isDraw })
 

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { getTopPlayers } from '@/lib/scoreboard-store'
+
+export async function GET() {
+  const topPlayers = getTopPlayers(5)
+  return NextResponse.json({ success: true, topPlayers })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useToast } from '@/hooks/use-toast'
 import { Copy, Share2, Users, Settings } from 'lucide-react'
 import { BLOCKED_CELL } from '@/lib/constants'
+import { Scoreboard } from '@/components/Scoreboard'
 
 interface Player {
   id: string
@@ -406,7 +407,8 @@ export default function Connect4() {
 
   if (isConfiguring) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen gap-8 p-4">
+      <div className="flex flex-col md:flex-row items-center justify-center min-h-screen gap-8 p-4">
+        <Scoreboard className="order-last md:order-first" />
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -508,7 +510,8 @@ export default function Connect4() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-8 p-4">
+    <div className="flex flex-col md:flex-row items-center justify-center min-h-screen gap-8 p-4">
+      <Scoreboard className="order-last md:order-first" />
       <Card className="w-full max-w-4xl">
         <CardHeader>
           <div className="flex items-center justify-between">

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { cn } from '@/lib/utils'
+
+interface ScoreEntry {
+  name: string
+  wins: number
+}
+
+export function Scoreboard({ className }: { className?: string }) {
+  const [scores, setScores] = useState<ScoreEntry[]>([])
+
+  const fetchScores = async () => {
+    try {
+      const res = await fetch('/api/scoreboard')
+      const data = await res.json()
+      if (data.success) {
+        setScores(data.topPlayers)
+      }
+    } catch (err) {
+      console.error('fetch scoreboard error', err)
+    }
+  }
+
+  useEffect(() => {
+    fetchScores()
+    const interval = setInterval(fetchScores, 5000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <Card className={cn("w-full max-w-xs", className)}>
+      <CardHeader>
+        <CardTitle>Scoreboard</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {scores.length === 0 && <p>No wins yet.</p>}
+        {scores.map((entry, idx) => (
+          <div key={entry.name} className="flex justify-between">
+            <span>{idx + 1}. {entry.name}</span>
+            <span>{entry.wins}</span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/scoreboard-store.ts
+++ b/src/lib/scoreboard-store.ts
@@ -1,0 +1,28 @@
+export interface ScoreEntry {
+  name: string
+  wins: number
+}
+
+declare global {
+  // scoreboard map where key is player name and value is wins
+  var scoreboard: Map<string, number> | undefined
+}
+
+const globalForScoreboard = globalThis as unknown as { scoreboard: Map<string, number> | undefined }
+
+export const scoreboard: Map<string, number> = globalForScoreboard.scoreboard ?? new Map()
+if (!globalForScoreboard.scoreboard) {
+  globalForScoreboard.scoreboard = scoreboard
+}
+
+export function addWin(name: string) {
+  const current = scoreboard.get(name) ?? 0
+  scoreboard.set(name, current + 1)
+}
+
+export function getTopPlayers(limit = 5): ScoreEntry[] {
+  return Array.from(scoreboard.entries())
+    .map(([name, wins]) => ({ name, wins }))
+    .sort((a, b) => b.wins - a.wins)
+    .slice(0, limit)
+}

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,6 +1,7 @@
 import { Server } from 'socket.io';
 import { getGame, updateGame } from '@/lib/game-store';
 import { BLOCKED_CELL } from '@/lib/constants';
+import { addWin } from '@/lib/scoreboard-store';
 
 export const setupSocket = (io: Server) => {
   io.on('connection', (socket) => {
@@ -80,6 +81,11 @@ export const setupSocket = (io: Server) => {
       };
 
       updateGame(gameId, updatedGame);
+
+      if (winner) {
+        const winnerName = game.players.find((p: any) => p.id === winner)?.name ?? 'Unknown';
+        addWin(winnerName);
+      }
 
       // Broadcast the updated game state to all players in the game
       io.to(`game-${gameId}`).emit('game-updated', updatedGame);
@@ -220,6 +226,11 @@ export const setupSocket = (io: Server) => {
           };
 
           updateGame(gameId, updatedGame);
+
+          if (winner) {
+            const winnerName = game.players.find((p: any) => p.id === winner)?.name ?? 'Unknown';
+            addWin(winnerName);
+          }
 
           // Broadcast the updated game state to all players in the game
           io.to(`game-${gameId}`).emit('game-updated', updatedGame);


### PR DESCRIPTION
## Summary
- keep track of player wins in a new scoreboard store
- expose an API endpoint to list the top players
- create a Scoreboard component that fetches and displays results
- update websocket and REST move handlers to record wins
- show the scoreboard beside the Connect 4 game/card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c0a04fc8c8324bf3d40fd99418ac3