### PR TITLE
Add game history display

### DIFF
--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { getGameHistory } from '@/lib/game-history'
+
+export async function GET() {
+  const games = getGameHistory()
+  return NextResponse.json({ success: true, games })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/hooks/use-toast'
 import { Copy, Share2, Users, Settings } from 'lucide-react'
 import { BLOCKED_CELL } from '@/lib/constants'
 import { Scoreboard } from '@/components/Scoreboard'
+import { History } from '@/components/History'
 
 interface Player {
   id: string
@@ -529,6 +530,7 @@ export default function Connect4() {
             </div>
           </CardContent>
         </Card>
+        <History className="order-last md:order-last md:h-[75vh]" />
       </div>
     )
   }
@@ -667,6 +669,7 @@ export default function Connect4() {
           </div>
         </CardContent>
       </Card>
+      <History className="order-last md:order-last md:h-[75vh]" />
     </div>
   )
 }

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
+import { cn } from '@/lib/utils'
+import { BLOCKED_CELL } from '@/lib/constants'
+
+interface GameSummary {
+  gameId: string
+  board: string[][]
+  boardSize: number
+  winner: { name: string; color: string } | null
+  isDraw: boolean
+  timestamp: string
+}
+
+export function History({ className }: { className?: string }) {
+  const [games, setGames] = useState<GameSummary[]>([])
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const res = await fetch('/api/history')
+        const data = await res.json()
+        if (data.success) {
+          setGames(data.games as GameSummary[])
+        }
+      } catch (err) {
+        console.error('fetch history error', err)
+      }
+    }
+    fetchHistory()
+  }, [])
+
+  return (
+    <Card className={cn('w-full max-w-xs', className)}>
+      <CardHeader>
+        <CardTitle>Game History</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 overflow-y-auto">
+        {games.length === 0 && <p>No games yet.</p>}
+        {games.map((game) => (
+          <div key={game.gameId} className="space-y-1">
+            <div className="text-xs">
+              {new Date(game.timestamp).toLocaleString()}
+            </div>
+            <div className="text-xs">
+              {game.winner ? (
+                <>Winner: <span style={{ color: game.winner.color }}>{game.winner.name}</span></>
+              ) : game.isDraw ? (
+                <>Draw</>
+              ) : (
+                <>In Progress</>
+              )}
+            </div>
+            <div className="inline-block bg-blue-500 p-1 rounded">
+              {game.board.map((row, rIdx) => (
+                <div key={rIdx} className="flex">
+                  {row.map((cell, cIdx) => (
+                    <div
+                      key={cIdx}
+                      className="w-4 h-4 bg-white border border-gray-300 rounded-full m-px flex items-center justify-center"
+                    >
+                      {cell === BLOCKED_CELL ? (
+                        <span className="text-[8px] font-bold">X</span>
+                      ) : cell ? (
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: cell }}
+                        />
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/game-history.ts
+++ b/src/lib/game-history.ts
@@ -1,0 +1,161 @@
+import fs from 'fs'
+import path from 'path'
+import { BLOCKED_CELL } from './constants'
+
+interface GameEvent {
+  type: 'game-created' | 'player-joined' | 'move' | 'block'
+  gameId: string
+  playerId?: string
+  playerName?: string
+  playerColor?: string
+  row?: number
+  col?: number
+  boardSize?: number
+  timestamp: string
+}
+
+interface PlayerInfo {
+  name: string
+  color: string
+}
+
+export interface GameSummary {
+  gameId: string
+  board: string[][]
+  boardSize: number
+  winner: { name: string; color: string } | null
+  isDraw: boolean
+  timestamp: string
+}
+
+const GAME_LOG_FILE = path.join(process.cwd(), 'game-log.json')
+
+function checkDirection(
+  board: string[][],
+  playerId: string,
+  row: number,
+  col: number,
+  deltaRow: number,
+  deltaCol: number,
+  boardSize: number
+): boolean {
+  let count = 1
+  let r = row + deltaRow
+  let c = col + deltaCol
+  while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === playerId) {
+    count++
+    r += deltaRow
+    c += deltaCol
+  }
+  r = row - deltaRow
+  c = col - deltaCol
+  while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === playerId) {
+    count++
+    r -= deltaRow
+    c -= deltaCol
+  }
+  return count >= 4
+}
+
+function checkWinner(
+  board: string[][],
+  playerId: string,
+  row: number,
+  col: number,
+  boardSize: number
+): boolean {
+  return (
+    checkDirection(board, playerId, row, col, 0, 1, boardSize) ||
+    checkDirection(board, playerId, row, col, 1, 0, boardSize) ||
+    checkDirection(board, playerId, row, col, 1, 1, boardSize) ||
+    checkDirection(board, playerId, row, col, 1, -1, boardSize)
+  )
+}
+
+export function getGameHistory(): GameSummary[] {
+  let events: GameEvent[] = []
+  try {
+    if (fs.existsSync(GAME_LOG_FILE)) {
+      const file = fs.readFileSync(GAME_LOG_FILE, 'utf8')
+      events = JSON.parse(file) as GameEvent[]
+    }
+  } catch (err) {
+    console.error('Failed to read game log', err)
+    return []
+  }
+
+  const games: Record<string, {
+    boardSize: number
+    board: string[][]
+    players: Record<string, PlayerInfo>
+    winner: string | null
+    isDraw: boolean
+    timestamp: string
+  }> = {}
+
+  for (const ev of events) {
+    if (ev.type === 'game-created') {
+      games[ev.gameId] = {
+        boardSize: ev.boardSize || 7,
+        board: Array(ev.boardSize || 7).fill(null).map(() => Array(ev.boardSize || 7).fill('')),
+        players: ev.playerId ? { [ev.playerId]: { name: ev.playerName || '', color: ev.playerColor || '#000' } } : {},
+        winner: null,
+        isDraw: false,
+        timestamp: ev.timestamp,
+      }
+    } else if (ev.type === 'player-joined') {
+      const g = games[ev.gameId]
+      if (g && ev.playerId) {
+        g.players[ev.playerId] = { name: ev.playerName || '', color: ev.playerColor || '#000' }
+      }
+    } else if (ev.type === 'block') {
+      const g = games[ev.gameId]
+      if (!g) continue
+      if (ev.row !== undefined && ev.col !== undefined) {
+        g.board[ev.row][ev.col] = BLOCKED_CELL
+        g.timestamp = ev.timestamp
+      }
+      if (!g.winner && !g.isDraw) {
+        if (g.board.flat().every(c => c !== '' && c !== BLOCKED_CELL)) {
+          g.isDraw = true
+        }
+      }
+    } else if (ev.type === 'move') {
+      const g = games[ev.gameId]
+      if (!g || ev.row === undefined || ev.col === undefined || !ev.playerId) continue
+      g.board[ev.row][ev.col] = ev.playerId
+      g.timestamp = ev.timestamp
+      if (!g.winner) {
+        if (checkWinner(g.board, ev.playerId, ev.row, ev.col, g.boardSize)) {
+          g.winner = ev.playerId
+        } else if (g.board.flat().every(c => c !== '' && c !== BLOCKED_CELL)) {
+          g.isDraw = true
+        }
+      }
+    }
+  }
+
+  const summaries: GameSummary[] = []
+  for (const [gameId, g] of Object.entries(games)) {
+    const boardColors = g.board.map(row =>
+      row.map(cell => {
+        if (cell === BLOCKED_CELL || cell === '') return cell
+        const p = g.players[cell]
+        return p ? p.color : cell
+      })
+    )
+    const winnerInfo = g.winner ? g.players[g.winner] : null
+    summaries.push({
+      gameId,
+      board: boardColors,
+      boardSize: g.boardSize,
+      winner: winnerInfo ? { name: winnerInfo.name, color: winnerInfo.color } : null,
+      isDraw: g.isDraw && !g.winner,
+      timestamp: g.timestamp,
+    })
+  }
+
+  summaries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+  return summaries
+}
+


### PR DESCRIPTION
## Summary
- create server util `getGameHistory` to parse `game-log.json`
- add `/api/history` route
- show results in new `History` component
- include `History` component next to the board

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c8299a70c83249cbedf489b79349d